### PR TITLE
Display duration configuration checkbox added for build report table

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -31,11 +31,12 @@ Last builds and show
 
 <select id="teststatus">
   <option value="all">All</option>
-  <option value="FAILED">FAILED</option>  
-  <option value="PASSED">PASSED</option>  
-  <option value="SKIPPED">SKIPPED</option>  
+  <option value="FAILED">FAILED</option>
+  <option value="PASSED">PASSED</option>
+  <option value="SKIPPED">SKIPPED</option>
 </select>
  tests.
+Display duration: <input type="checkbox" id="show-durations" name="show-durations" value="durations"/>
 
 <button id="getbuildreport">Get Build Report</button>
 <div class="extrabuttons">
@@ -52,6 +53,7 @@ Select chart type:
    <option value="bar">Bar</option>
    <option value="pie">Pie</option>
  </select>
+
 <button class = "charts" id="generatechart">Generate Charts</button>
 <button class = "charts" id="hidecharts">Hide Charts</button>
 </div>
@@ -87,7 +89,8 @@ Select chart type:
 
 <script>
 	$j("#getbuildreport").click(function () {
-		populateTemplate();
+        var displayValues = $j("#show-durations").is(":checked");
+		populateTemplate(displayValues);
 	});
 	
 	$j("#expandall").click(function () {

--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -89,7 +89,6 @@ Select chart type:
 
 <script>
 	$j("#getbuildreport").click(function () {
-        var displayValues = $j("#show-durations").is(":checked");
 		populateTemplate(displayValues);
 	});
 	

--- a/src/main/webapp/js/test-result-analyzer-template.js
+++ b/src/main/webapp/js/test-result-analyzer-template.js
@@ -75,8 +75,8 @@ Handlebars.registerHelper('addName', function (name) {
 });
 
 Handlebars.registerHelper('applyvalue', function (status, totalTimeTaken) {
-    if (displayValuesFlag == true){
-        return totalTimeTaken;
+    if (displayValues == true){
+        return isNaN(totalTimeTaken) ? '' : totalTimeTaken.toFixed(3) ;
     }else{
         return status;
     }

--- a/src/main/webapp/js/test-result-analyzer-template.js
+++ b/src/main/webapp/js/test-result-analyzer-template.js
@@ -13,7 +13,7 @@ var tableContent = '<div class="table-row {{parentclass}}-{{addName text}}" pare
         '>&nbsp;{{text}}</div>' +
     '' +
     '{{#each this.buildResults}}' +
-    '\n' + '         <div class="table-cell build-result {{applystatus status}}" data-result=\'{{JSON2string this}}\'>{{status}}</div>' +
+    '\n' + '         <div class="table-cell build-result {{applystatus status}}" data-result=\'{{JSON2string this}}\'>{{applyvalue status totalTimeTaken}}</div>' +
     '{{/each}}' +
     '\n' + '</div>' +
     '{{#each children}}\n' +
@@ -73,6 +73,15 @@ Handlebars.registerHelper('storeParent', function (context, key, value1, value2,
 Handlebars.registerHelper('addName', function (name) {
     return removeSpecialChars(name);
 });
+
+Handlebars.registerHelper('applyvalue', function (status, totalTimeTaken) {
+    if (displayValuesFlag == true){
+        return totalTimeTaken;
+    }else{
+        return status;
+    }
+});
+
 
 Handlebars.registerHelper('applystatus', function (status) {
     var statusClass = "no_status";

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -1,6 +1,7 @@
 var colTemplate = "{'cellClass':'col1','value':'build20','header':'20','title':'20'}";
 var treeMarkup = "";
 var reevaluateChartData = true;
+var displayValuesFlag = true;
 function reset(){
     reevaluateChartData = true;
     $j(".table").html("")
@@ -8,12 +9,13 @@ function reset(){
     resetCharts();
 }
 
-function populateTemplate(){
+function populateTemplate(displayValues){
     reset();
+    displayValuesFlag = displayValues;
     var noOfBuilds = $j('#noofbuilds').val();
     remoteAction.getTreeResult(noOfBuilds,$j.proxy(function(t) {
         var itemsResponse = t.responseObject();
-        treeMarkup = analyzerTemplate(itemsResponse);
+        treeMarkup = analyzerTemplate(itemsResponse, displayValues);
         $j(".table").html(treeMarkup);
         addEvents();
     },this));

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -1,7 +1,8 @@
 var colTemplate = "{'cellClass':'col1','value':'build20','header':'20','title':'20'}";
 var treeMarkup = "";
 var reevaluateChartData = true;
-var displayValuesFlag = true;
+var displayValues = false;
+
 function reset(){
     reevaluateChartData = true;
     $j(".table").html("")
@@ -9,13 +10,14 @@ function reset(){
     resetCharts();
 }
 
-function populateTemplate(displayValues){
+function populateTemplate(){
     reset();
-    displayValuesFlag = displayValues;
     var noOfBuilds = $j('#noofbuilds').val();
+    displayValues  = $j("#show-durations").is(":checked");
+
     remoteAction.getTreeResult(noOfBuilds,$j.proxy(function(t) {
         var itemsResponse = t.responseObject();
-        treeMarkup = analyzerTemplate(itemsResponse, displayValues);
+        treeMarkup = analyzerTemplate(itemsResponse);
         $j(".table").html(treeMarkup);
         addEvents();
     },this));


### PR DESCRIPTION
Total test times and test times for specific test cases are Important for performance regression tests reports. Please review example in the following screenshot
![capture](https://cloud.githubusercontent.com/assets/3119949/8667843/7863151e-2a0d-11e5-9489-c888699d5371.PNG)

In the future I'm planning also to generate chart of duration for every testcase

