### PR TITLE
add support to create specified number of builds

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -20,22 +20,18 @@ var $j = jQuery.noConflict();
 <j:set var="temp" value="${it.jsonLoadData}"/>
 <j:set var="builds" value="${it.builds}"/>
 <div>
-Select
-<select id="noofbuilds">
-  <option value="all">All</option>
-  <option value="10">10</option>
-  <option value="20">20</option>
-  <option value="30">30</option>
-</select>
-Last builds and show
-
+Number of latest builds:
+<input id="noofbuilds" type="number" min="1" step="1" value="10" disabled="true" />
+(all: <input id="allnoofbuilds" type="checkbox" checked="true" />)
+<br />
+Show
 <select id="teststatus">
   <option value="all">All</option>
   <option value="FAILED">FAILED</option>
   <option value="PASSED">PASSED</option>
   <option value="SKIPPED">SKIPPED</option>
 </select>
- tests.
+ tests
  <br/>Advanced options: <input type="checkbox" id="show-advanced-options" name="show-advanced-options"/>
  <button id="getbuildreport">Get Build Report</button>
  <div id="advancedOptions" style="display:none">
@@ -98,6 +94,9 @@ Select chart type:
             download("Test Results.csv", t.responseObject());
         })
     });
+    $j("#allnoofbuilds").on("change", function() {
+        $j("#noofbuilds").attr("disabled", this.checked);
+    })
 	$j("#getbuildreport").click(function () {
 		 $j("#downloadCSV").css("display", "block");
 		populateTemplate();

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -12,7 +12,7 @@ function reset(){
 
 function populateTemplate(){
     reset();
-    var noOfBuilds = $j('#noofbuilds').val();
+    var noOfBuilds = $j("#allnoofbuilds").is(":checked") ? "all" : $j('#noofbuilds').val();
     displayValues  = $j("#show-build-durations").is(":checked");
 
     remoteAction.getTreeResult(noOfBuilds,$j.proxy(function(t) {


### PR DESCRIPTION
__Add support to specify how many builds you want to get from the report.__
Check the "all" checkbox will disable the input box next to it, and uncheck the "all" checkbox will enable the input box next to it.
Snapshots
------
<img width="377" alt="screen shot 2015-12-11 at 8 05 58 pm" src="https://cloud.githubusercontent.com/assets/5692933/11759575/bdc415b2-a042-11e5-8b17-ff65a7e2af5e.png">
<img width="369" alt="screen shot 2015-12-11 at 8 06 06 pm" src="https://cloud.githubusercontent.com/assets/5692933/11759573/b03ba55e-a042-11e5-8468-2a5c637ec549.png">
