### PR TITLE
Combine New Failures/Children Column with Test Column

### DIFF
--- a/src/main/webapp/js/test-result-analyzer-template.js
+++ b/src/main/webapp/js/test-result-analyzer-template.js
@@ -3,15 +3,16 @@ var tableContent = '<div class="table-row {{parentclass}}-{{addName text}}" pare
     '\n' + '         ' +
     '\n' + '         <div class="table-cell"><div class="icon icon-exclamation-sign" style="display:none" ></div></div>' +
     '\n' + '         <div class="table-cell"><input type="checkbox" parentclass= "{{parentclass}}" parentname="{{parentname}}" name = "checkbox-{{addName text}}" result-name = "{{addName text}}"/></div> ' +
-    '<div class="children  table-cell" >  ' +
-    '{{#if children}}' +
-        '<div class="icon icon-plus-sign" ></div> ' +
-    '{{/if}}</div>' +
     ' <div class="name row-heading table-cell" ' +
         '{{#if hierarchyLevel}}' +
             'style="padding-left:{{addspaces hierarchyLevel}}em;"' +
         '{{/if}}' +
-        '>&nbsp;{{text}}</div>' +
+    '>' +
+        '{{#if children}}' +
+            '<span class="icon icon-plus-sign" title="Show Children"></span> ' +
+        '{{/if}}' +
+        '&nbsp;{{text}}</span>' +
+    '</div>' +
     '' +
     '{{#each this.buildResults}}' +
     '\n' + '         <div class="table-cell build-result {{applystatus status}}" is-config="{{isConfig}}" data-result=\'{{JSON2string this}}\'><a href="{{url}}">{{applyvalue status totalTimeTaken}}</a></div>' +
@@ -27,7 +28,8 @@ var tableContent = '<div class="table-row {{parentclass}}-{{addName text}}" pare
 
 var tableBody = '<div class="heading">' +
     '\n' + '        <div class="table-cell" >New Failures</div>' +
-    '\n' + '        <div class="table-cell">Chart</div><div class="table-cell">See children</div> <div class="table-cell">Build Number &rArr;<br>Package-Class-Testmethod names &dArr;</div>' +
+    '\n' + '        <div class="table-cell">Chart</div> ' +
+    '<div class="table-cell">Build Number &rArr;<br>Package-Class-Testmethod names &dArr;</div>' +
     '{{#each builds}}' +
     '\n' + '         <div class="table-cell">{{this}}</div>' +
     '{{/each}}' +

--- a/src/main/webapp/js/test-result-analyzer-template.js
+++ b/src/main/webapp/js/test-result-analyzer-template.js
@@ -1,7 +1,6 @@
 var tableContent = '<div class="table-row {{parentclass}}-{{addName text}}" parentclass= "{{parentclass}}" parentname="{{parentname}}" name = "{{addName text}}" {{#if isChild}} style="display:none"{{/if}}>' +
     '\n' + '         ' +
     '\n' + '         ' +
-    '\n' + '         <div class="table-cell"><div class="icon icon-exclamation-sign" style="display:none" ></div></div>' +
     '\n' + '         <div class="table-cell"><input type="checkbox" parentclass= "{{parentclass}}" parentname="{{parentname}}" name = "checkbox-{{addName text}}" result-name = "{{addName text}}"/></div> ' +
     ' <div class="name row-heading table-cell" ' +
         '{{#if hierarchyLevel}}' +
@@ -11,6 +10,7 @@ var tableContent = '<div class="table-row {{parentclass}}-{{addName text}}" pare
         '{{#if children}}' +
             '<span class="icon icon-plus-sign" title="Show Children"></span> ' +
         '{{/if}}' +
+        '<span class="{{failureIconWhenNecessary buildResults}}" title="New Failure" ></span>' +
         '&nbsp;{{text}}</span>' +
     '</div>' +
     '' +
@@ -27,7 +27,6 @@ var tableContent = '<div class="table-row {{parentclass}}-{{addName text}}" pare
     '{{/each}}';
 
 var tableBody = '<div class="heading">' +
-    '\n' + '        <div class="table-cell" >New Failures</div>' +
     '\n' + '        <div class="table-cell">Chart</div> ' +
     '<div class="table-cell">Build Number &rArr;<br>Package-Class-Testmethod names &dArr;</div>' +
     '{{#each builds}}' +
@@ -141,4 +140,16 @@ Handlebars.registerHelper('addHierarchy', function (context, parentHierarchy, op
     context["hierarchyLevel"] = parentHierarchy + 1;
 });
 
+Handlebars.registerHelper('failureIconWhenNecessary', function (buildResults) {
+    if (buildResults.length < 2) {
+        return '';
+    }
+
+    if (buildResults[0].status == "FAILED" &&
+        buildResults[1].status == "PASSED") {
+        return 'icon icon-exclamation-sign';
+    } else {
+        return '';
+    }
+});
 var analyzerTemplate = Handlebars.compile(tableBody);

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -3,23 +3,6 @@ var treeMarkup = "";
 var reevaluateChartData = true;
 var displayValues = false;
 
-function newFailingTests(){
-    var table_rows = $j(".table-row");
-    var i;
-    for (i=0;i<table_rows.length;i++){
-        row = table_rows[i];
-            row_cells = $j(row).find(".build-result");
-            last_test = row_cells[0];
-            if (!JSON.parse($j(last_test).attr("data-result"))["isPassed"] && row_cells.length>1){
-                second_to_last = row_cells[1];
-                if (JSON.parse($j(second_to_last).attr("data-result"))["isPassed"]){
-                    var cell = $j(row).find(".icon-exclamation-sign")[0];
-                    $j(cell).css("display","inline-block");
-                }   
-            }
-    }
-}
-
 function searchTests(){
     var table = $j(".table")[0];
     var rows = $j(table).find(".table-row");
@@ -152,7 +135,7 @@ function addEvents() {
             $j(node).addClass('icon-minus-sign');
             $j(node).attr('title', 'Hide Children');
             $j(childLocator).show();
-        } else {
+        } else if ($j(node).hasClass('icon-minus-sign')) {
             $j(node).removeClass('icon-minus-sign');
             $j(node).addClass('icon-plus-sign');
             $j(node).attr('title', 'Show Children');
@@ -184,7 +167,6 @@ function addEvents() {
         toggleHandler(this);
     });
     checkBoxEvents();
-    newFailingTests();
 }
 
 function checkBoxEvents() {

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -150,10 +150,12 @@ function addEvents() {
         if ($j(node).hasClass('icon-plus-sign')) {
             $j(node).removeClass('icon-plus-sign');
             $j(node).addClass('icon-minus-sign');
+            $j(node).attr('title', 'Hide Children');
             $j(childLocator).show();
         } else {
             $j(node).removeClass('icon-minus-sign');
             $j(node).addClass('icon-plus-sign');
+            $j(node).attr('title', 'Show Children');
             $j(childLocator).hide();
             hideChilds($j(childLocator));
         }
@@ -165,9 +167,11 @@ function addEvents() {
             var nodeName = $j(this).parent().parent(".table-row").attr("name");
             var childLocator = "[parentclass='" + parent + "-" + nodeName + "']";
 
-            if ($j(this).find('.icon').hasClass('icon-minus-sign')) {
-                $j(this).find('.icon').removeClass('icon-minus-sign');
-                $j(this).find('.icon').addClass('icon-plus-sign');
+            var icon = $j(this).find('.icon');
+            if (icon.hasClass('icon-minus-sign')) {
+                icon.removeClass('icon-minus-sign');
+                icon.addClass('icon-plus-sign');
+                icon.attr('title', 'Show Children');
             }
             var childElements = $j(childLocator);
             childElements.hide();


### PR DESCRIPTION
Removes both the new failures column and the children column.
The information is now displayed next to the test name, leading to more compact tables.
Tool-tips are added to ensure that people still know what these icons are for.