### PR TITLE
JENKINS-48626 use display name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ target
 .project
 .settings
 .idea
+*.iml
 work

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/result/info/ClassInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/result/info/ClassInfo.java
@@ -27,7 +27,7 @@ public class ClassInfo extends Info {
 	private void addTests(Integer buildNumber, TabulatedResult classResult, String url) {
 		for (TestResult testCaseResult : classResult.getChildren()) {
 
-			String testCaseName = testCaseResult.getName();
+			String testCaseName = testCaseResult.getDisplayName();
 			TestCaseInfo testCaseInfo;
 			if (tests.containsKey(testCaseName)) {
 				testCaseInfo = tests.get(testCaseName);


### PR DESCRIPTION
The information about the stage and parallel block was missing in the name of the test. Only the last test result was shown cause the simple name was used as map key.