### PR TITLE
Add a field on the page to show a custom amount of "broken test"

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -98,6 +98,9 @@ Search: <input id="filter" class="table-filter" type="text" placeholder="Test/Cl
    </div>
    <br/>
 
+   <div class="show-after-loading">
+       Show <input id="brokencount" type="text" value="20" onkeyup="showBroken()" /> broken tests
+   </div>
    <div class="worst-tests-table">
 
    </div>

--- a/src/main/webapp/css/table-style.css
+++ b/src/main/webapp/css/table-style.css
@@ -141,5 +141,10 @@
         margin-top: 10%;
     }
 
+    .show-after-loading {
+        display: none;
+    }
 
-	
+    #brokencount {
+        width: 3.5em;
+    }

--- a/src/main/webapp/js/test-result-analyzer-template.js
+++ b/src/main/webapp/js/test-result-analyzer-template.js
@@ -50,7 +50,7 @@ var tableBody = '<div class="heading">' +
     '{{> tableBodyTemplate}}' +
     '\n' + '{{/each}}';
 
-var worstTestsTableBody = '<h2 align="center">Top 10 Most Broken Tests</h2>' +
+var worstTestsTableBody = '<h2 align="center">Top {{this.length}} Most Broken Tests</h2>' +
     '\n' + '{{#if this.length}}' +
     '<div class=table>' +
     '\n' + '<div class="heading">' +

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -50,11 +50,26 @@ function searchTests(){
     }
 }
 
+function showBroken() {
+    var count = $j("#brokencount").val();
+    if (!isNaN(count)) {
+        populateWorstTests(parseInt(count));
+    }
+}
+
 function reset(){
     reevaluateChartData = true;
     $j(".test-history-table").html("");
     $j(".worst-tests-table").html("");
     resetCharts();
+}
+
+function populateWorstTests(count) {
+    var items = populateWorstTests.items;
+    var worstTests = getWorstTests(items, count);
+    $j(".worst-tests-table").html(
+        analyzerWorstTestsTemplate(worstTests)
+    );
 }
 
 function populateTemplate(){
@@ -66,10 +81,10 @@ function populateTemplate(){
         $j(".test-history-table").html(
             analyzerTemplate(itemsResponse)
         );
-        var worstTests = getWorstTests(itemsResponse);
-        $j(".worst-tests-table").html(
-            analyzerWorstTestsTemplate(worstTests)
-        );
+        $j(".show-after-loading").show();
+        /* Set the function's static variable */
+        populateWorstTests.items = itemsResponse;
+        populateWorstTests(20);
         addEvents();
         generateCharts();
         $j("#table-loading").hide();


### PR DESCRIPTION
For my own needs, I had to show more than (top) 10 most broken tests. Thus, the easiest way to do was to add a new field to the test result view page. From there, a field is available to input the number of most broken tests to show.
I think this change can benefit to other users.