### PR TITLE
Require 2.332.4 as minimum Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<properties>
 		<!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-		<jenkins.version>2.235.1</jenkins.version>
+		<jenkins.version>2.332.4</jenkins.version>
 		<!-- Jenkins Test Harness version you use to test the plugin. -->
 		<!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
 		<!-- <jenkins-test-harness.version>2.13</jenkins-test-harness.version> -->
@@ -45,11 +45,22 @@
 	  <tag>HEAD</tag>
   </scm>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1607.va_c1576527071</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.47</version>
         </dependency>
     </dependencies>
 	<!-- get every artifact through repo.jenkins-ci.org, which proxies all the


### PR DESCRIPTION
acknowledge that we don't support Jenkins version below 2.332.4

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

# PR Details

- Updated the Jenkins version to **2.332.4** (a version before LTS)
- Implemented the **BOM to remove the UpperBoundDeps error**
- Removed **version** property of **junit** as it is no longer needed 
