### PR TITLE
use https for scm url instead of ssh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:ssh://git@github.com:jenkinsci/test-results-analyzer-plugin.git</connection>
+		<connection>scm:git:https://github.com/jenkinsci/test-results-analyzer-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/test-results-analyzer-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/test-results-analyzer-plugin.git</url>
 	  <tag>HEAD</tag>


### PR DESCRIPTION
**changed the general purpose scm url protocol to HTTPS**

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did

# PR Motive
- We don't need to use **SSH** protocol for read-only 
- the general purpose key should be **HTTPS** as we don't need any kind of private key to register to GitHub.
