### PR TITLE
Report an issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## [Test Results Analyzer](https://plugins.jenkins.io/test-results-analyzer/)
+# [Test Results Analyzer](https://plugins.jenkins.io/test-results-analyzer/)
 
 - A plugin that shows history of test execution results in a tabular format.
 - The results are shown in a tree grid hierarchy and user has the provision to drill-down to test-method level to see the execution status of the respective set across multiple builds.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## test-results-analyzer
+## [Test Results Analyzer](https://plugins.jenkins.io/test-results-analyzer/)
 
 - A plugin that shows history of test execution results in a tabular format.
 - The results are shown in a tree grid hierarchy and user has the provision to drill-down to test-method level to see the execution status of the respective set across multiple builds.
@@ -37,16 +37,16 @@ execution as it gives us a clear picture of the execution. The said
 plugin also supports generation of Graphs for the test execution from
 0.2.0 version onwards.
 
-# Following charts are available 
+### Following charts are available 
 
-## Line Charts
+### Line Charts
  
 ![](docs/images/line-chart-2.1.png)  
 
-##  Pie Charts
+###  Pie Charts
 ![](docs/images/pie-chart-2.1.png)  
 
-## Bar Charts
+### Bar Charts
 ![](docs/images/bar-chart-2.1.png)  
 
 **Note**: **If you click on any point on the line chart it will generate
@@ -59,3 +59,8 @@ a pie chart for said build/point.**
 
 ## License
 [**Apache-2.0 license**](https://www.apache.org/licenses/LICENSE-2.0)
+
+
+## Report an Issue
+Please report issues and enhancements through the
+[Jenkins issue tracker](https://www.jenkins.io/participate/report-issue/redirect/#19327).


### PR DESCRIPTION
The plugins [site](https://plugins.jenkins.io/) includes a “Report an Issue” link for each of the plugins. **The linked page guides the user to provide a better classified issue and leads them to the correct path to privately report security issues.**

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did

 ## PR Details
*  Added a `Report an Issue` section in README.md
*  Refactored README.md
    - **There is no way to go the respective [plugin page](https://plugins.jenkins.io/test-results-analyzer/) from the repository.
    - So, embedded a Link in main heading which takes us to the plugin page of our plugin.
    - Refactored some heading into subheadings for the graphs section 

