### PR TITLE
Correct dependabot labeling configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,3 @@ updates:
   - MarkEWaite
   - gounthar
   - jmMeessen
-  labels:
-  - skip-changelog


### PR DESCRIPTION
Changing the dependabot labeling configuration to use the default `dependencies` label. In this case, the automatic labeling didn't work as the specified `skip-changelog` does not exist.