### PR TITLE
[JENKINS-72358] Replace Prototype.js `$(var)` with `var`

### DIFF
--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -137,7 +137,7 @@ function expandAll() {
 }
 
 function getDescendants(parentRow, level) {
-    var parentLevel = parseInt($(parentRow).attr("hierarchyLevel"));
+    var parentLevel = parseInt(parentRow.attr("hierarchyLevel"));
     var descendantLevel = parentLevel + level;
     var done = false;
 
@@ -167,7 +167,7 @@ function getAllDescendants(parentRow) {
 function getAllAncestors(parentRow) {
     var result = [];
 
-    var parentLevel = parseInt($(parentRow).attr("hierarchyLevel"));
+    var parentLevel = parseInt(parentRow.attr("hierarchyLevel"));
     var nextAncestorLevel = parentLevel - 1;
 
     var done = parentLevel < 0; // might not have any ancestors
@@ -218,7 +218,7 @@ function getSiblings(row) {
     done = false;
     var followingSiblings = $j(row).nextAll().filter(isSibling);
 
-    return $(previousSiblings).add(followingSiblings);
+    return previousSiblings.add(followingSiblings);
 }
 
 function addEvents() {
@@ -271,7 +271,7 @@ function checkChildren(row, checked) {
 
 function areAllSiblingsChecked(row) {
     var siblings = getSiblings(row);
-    return $(siblings).find("input:checked").length == siblings.length;
+    return siblings.find("input:checked").length == siblings.length;
 }
 
 function checkParent(row, checked) {


### PR DESCRIPTION
## [JENKINS-72358] Replace Prototype.js `$(var)` with `var`

[JENKINS-72358](https://issues.jenkins.io/browse/JENKINS-72358) reports a JavaScript error when the plus sign is clicked to expand the test results analyzer tree.

The [blog post](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/) recommends replacing `$(variable)` with `variable`.  That's what I did in 3 cases in this change.

I've confirmed that the JavaScript message that was displayed with the released version of the plugin is not displayed with these changes.

### Testing done

Interactively verified that I could see the JavaScript warning messages in the web developer console before this change and that the warning messages did not appear after the change.  The UI behaved incorrectly before the change and behaved correctly after the change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
