### PR TITLE
feature-hide N/A tests configurable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
@@ -33,7 +33,7 @@ public class JsTreeUtil {
         return tree;
     }
 
-        private JSONObject createJson(
+    private JSONObject createJson(
             List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
         JSONArray children = getChildren(builds, info, hideConfigMethods, hideNATestsThreshold);
         boolean leafNode = isLeafNode(info);
@@ -63,7 +63,7 @@ public class JsTreeUtil {
         return treeDataJson;
     }
 
-        private JSONArray getChildren(
+    private JSONArray getChildren(
             List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
         Map<String, ? extends Info> childrenInfo = info.getChildren();
         if (childrenInfo == null) return new JSONArray();

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
@@ -91,13 +91,18 @@ public class JsTreeUtil {
             return false;
         }
 
-        int naCount = 0;
+        int consecutiveNaCount = 0;
         for (Integer buildNumber : builds) {
             if (info.getBuildResult(buildNumber) == null) {
-                naCount++;
+                consecutiveNaCount++;
+                if (consecutiveNaCount >= hideNATestsThreshold) {
+                    return true;
+                }
+            } else {
+                break;
             }
         }
-        return naCount >= hideNATestsThreshold;
+        return false;
     }
 
     private JSONObject getBuild(Integer buildNumber, Info info) {

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
@@ -10,7 +10,8 @@ import org.jenkinsci.plugins.testresultsanalyzer.result.info.ResultInfo;
 
 public class JsTreeUtil {
 
-    public JSONObject getJsTree(List<Integer> builds, ResultInfo resultInfo, boolean hideConfigMethods) {
+    public JSONObject getJsTree(
+            List<Integer> builds, ResultInfo resultInfo, boolean hideConfigMethods, int hideNATestsThreshold) {
         JSONObject tree = new JSONObject();
 
         JSONArray buildJson = new JSONArray();
@@ -22,19 +23,33 @@ public class JsTreeUtil {
         JSONArray results = new JSONArray();
         for (Map.Entry<String, ? extends Info> entry :
                 resultInfo.getPackageResults().entrySet()) {
-            results.add(createJson(builds, entry.getValue(), hideConfigMethods));
+            JSONObject node = createJson(builds, entry.getValue(), hideConfigMethods, hideNATestsThreshold);
+            if (node != null) {
+                results.add(node);
+            }
         }
         tree.put("results", results);
 
         return tree;
     }
 
-    private JSONObject createJson(List<Integer> builds, Info info, boolean hideConfigMethods) {
+    private JSONObject createJson(List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
+        JSONArray children = getChildren(builds, info, hideConfigMethods, hideNATestsThreshold);
+        boolean leafNode = isLeafNode(info);
+
+        if (leafNode && shouldHideForNAThreshold(builds, info, hideNATestsThreshold)) {
+            return null;
+        }
+
+        if (!leafNode && children.isEmpty()) {
+            return null;
+        }
+
         JSONObject baseJson = new JSONObject();
 
         baseJson.put("text", info.getName());
         baseJson.put("buildResults", getBuilds(builds, info));
-        baseJson.put("children", getChildren(builds, info, hideConfigMethods));
+        baseJson.put("children", children);
 
         return baseJson;
     }
@@ -47,18 +62,40 @@ public class JsTreeUtil {
         return treeDataJson;
     }
 
-    private JSONArray getChildren(List<Integer> builds, Info info, boolean hideConfigMethods) {
+    private JSONArray getChildren(List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
         Map<String, ? extends Info> childrenInfo = info.getChildren();
         if (childrenInfo == null) return new JSONArray();
 
         JSONArray children = new JSONArray();
         for (Map.Entry<String, ? extends Info> entry : childrenInfo.entrySet()) {
             if (!hideConfigMethods || !entry.getValue().isConfig()) {
-                children.add(createJson(builds, entry.getValue(), hideConfigMethods));
+                JSONObject child = createJson(builds, entry.getValue(), hideConfigMethods, hideNATestsThreshold);
+                if (child != null) {
+                    children.add(child);
+                }
             }
         }
 
         return children;
+    }
+
+    private boolean isLeafNode(Info info) {
+        Map<String, ? extends Info> childrenInfo = info.getChildren();
+        return childrenInfo == null || childrenInfo.isEmpty();
+    }
+
+    private boolean shouldHideForNAThreshold(List<Integer> builds, Info info, int hideNATestsThreshold) {
+        if (hideNATestsThreshold <= 0) {
+            return false;
+        }
+
+        int naCount = 0;
+        for (Integer buildNumber : builds) {
+            if (info.getBuildResult(buildNumber) == null) {
+                naCount++;
+            }
+        }
+        return naCount >= hideNATestsThreshold;
     }
 
     private JSONObject getBuild(Integer buildNumber, Info info) {

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtil.java
@@ -33,7 +33,8 @@ public class JsTreeUtil {
         return tree;
     }
 
-    private JSONObject createJson(List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
+        private JSONObject createJson(
+            List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
         JSONArray children = getChildren(builds, info, hideConfigMethods, hideNATestsThreshold);
         boolean leafNode = isLeafNode(info);
 
@@ -62,7 +63,8 @@ public class JsTreeUtil {
         return treeDataJson;
     }
 
-    private JSONArray getChildren(List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
+        private JSONArray getChildren(
+            List<Integer> builds, Info info, boolean hideConfigMethods, int hideNATestsThreshold) {
         Map<String, ? extends Info> childrenInfo = info.getChildren();
         if (childrenInfo == null) return new JSONArray();
 

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction.java
@@ -209,9 +209,20 @@ public class TestResultsAnalyzerAction extends Actionable implements Action {
 
         int noOfBuilds = getNoOfBuildRequired(userConfig.getNoOfBuildsNeeded());
         List<Integer> buildList = getBuildList(noOfBuilds);
+        int hideNATestsThreshold = getNonNegativeValue(userConfig.getHideNATestsThreshold(), getHideNATestsThreshold());
 
         JsTreeUtil jsTreeUtils = new JsTreeUtil();
-        return jsTreeUtils.getJsTree(buildList, resultInfo, userConfig.isHideConfigMethods());
+        return jsTreeUtils.getJsTree(buildList, resultInfo, userConfig.isHideConfigMethods(), hideNATestsThreshold);
+    }
+
+    private int getNonNegativeValue(String value, int defaultValue) {
+        int parsedValue;
+        try {
+            parsedValue = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            parsedValue = defaultValue;
+        }
+        return Math.max(parsedValue, 0);
     }
 
     @JavaScriptMethod
@@ -315,6 +326,10 @@ public class TestResultsAnalyzerAction extends Actionable implements Action {
 
     public boolean getHideConfigurationMethods() {
         return TestResultsAnalyzerExtension.DESCRIPTOR.getHideConfigurationMethods();
+    }
+
+    public int getHideNATestsThreshold() {
+        return TestResultsAnalyzerExtension.DESCRIPTOR.getHideNATestsThreshold();
     }
 
     public String getChartDataType() {

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension.java
@@ -11,11 +11,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.verb.POST;
 
 @Extension
 public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
@@ -242,7 +244,10 @@ public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
             return intValidation(noOfBuilds);
         }
 
+        @POST
         public FormValidation doCheckHideNATestsThreshold(@QueryParameter String hideNATestsThreshold) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
             FormValidation result = intValidation(hideNATestsThreshold);
             if (result.kind != FormValidation.Kind.OK) {
                 return result;

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension.java
@@ -92,49 +92,45 @@ public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
 
         @Override
         public boolean configure(StaplerRequest2 req, JSONObject formData) {
-            try {
-                noOfBuilds = formData.getString("noOfBuilds");
-                noOfRunsToFetch = formData.getInt("noOfRunsToFetch");
-                showAllBuilds = formData.getBoolean("showAllBuilds");
-                showBuildTime = formData.getBoolean("showBuildTime");
-                hideConfigurationMethods = formData.getBoolean("hideConfigurationMethods");
-                hideNATestsThreshold = formData.getInt("hideNATestsThreshold");
-                showLineGraph = formData.getBoolean("showLineGraph");
-                showBarGraph = formData.getBoolean("showBarGraph");
-                showPieGraph = formData.getBoolean("showPieGraph");
-                runTimeLowThreshold = formData.getString("runTimeLowThreshold");
-                runTimeHighThreshold = formData.getString("runTimeHighThreshold");
-                chartDataType = formData.getString("chartDataType");
-                if (formData.containsKey("useCustomStatusNames")) {
-                    JSONObject customData = formData.getJSONObject("useCustomStatusNames");
-                    useCustomStatusNames = true;
-                    passedRepresentation = customData.getString("passedRepresentation");
-                    failedRepresentation = customData.getString("failedRepresentation");
-                    skippedRepresentation = customData.getString("skippedRepresentation");
-                    naRepresentation = customData.getString("naRepresentation");
-                } else {
-                    useCustomStatusNames = false;
-                    passedRepresentation = PASSED_REPRESENTATION;
-                    failedRepresentation = FAILED_REPRESENTATION;
-                    skippedRepresentation = SKIPPED_REPRESENTATION;
-                    naRepresentation = NA_REPRESENTATION;
-                }
-                if (formData.containsKey("useCustomStatusColors")) {
-                    JSONObject customData = formData.getJSONObject("useCustomStatusColors");
-                    useCustomStatusColors = true;
-                    passedColor = customData.getString("passedColor");
-                    failedColor = customData.getString("failedColor");
-                    skippedColor = customData.getString("skippedColor");
-                    naColor = customData.getString("naColor");
-                } else {
-                    useCustomStatusColors = false;
-                    passedColor = PASSED_STATUS_COLOR;
-                    failedColor = FAILED_STATUS_COLOR;
-                    skippedColor = SKIP_STATUS_COLOR;
-                    naColor = NA_STATUS_COLOR;
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+            noOfBuilds = formData.getString("noOfBuilds");
+            noOfRunsToFetch = formData.getInt("noOfRunsToFetch");
+            showAllBuilds = formData.getBoolean("showAllBuilds");
+            showBuildTime = formData.getBoolean("showBuildTime");
+            hideConfigurationMethods = formData.getBoolean("hideConfigurationMethods");
+            hideNATestsThreshold = formData.getInt("hideNATestsThreshold");
+            showLineGraph = formData.getBoolean("showLineGraph");
+            showBarGraph = formData.getBoolean("showBarGraph");
+            showPieGraph = formData.getBoolean("showPieGraph");
+            runTimeLowThreshold = formData.getString("runTimeLowThreshold");
+            runTimeHighThreshold = formData.getString("runTimeHighThreshold");
+            chartDataType = formData.getString("chartDataType");
+            if (formData.containsKey("useCustomStatusNames")) {
+                JSONObject customData = formData.getJSONObject("useCustomStatusNames");
+                useCustomStatusNames = true;
+                passedRepresentation = customData.getString("passedRepresentation");
+                failedRepresentation = customData.getString("failedRepresentation");
+                skippedRepresentation = customData.getString("skippedRepresentation");
+                naRepresentation = customData.getString("naRepresentation");
+            } else {
+                useCustomStatusNames = false;
+                passedRepresentation = PASSED_REPRESENTATION;
+                failedRepresentation = FAILED_REPRESENTATION;
+                skippedRepresentation = SKIPPED_REPRESENTATION;
+                naRepresentation = NA_REPRESENTATION;
+            }
+            if (formData.containsKey("useCustomStatusColors")) {
+                JSONObject customData = formData.getJSONObject("useCustomStatusColors");
+                useCustomStatusColors = true;
+                passedColor = customData.getString("passedColor");
+                failedColor = customData.getString("failedColor");
+                skippedColor = customData.getString("skippedColor");
+                naColor = customData.getString("naColor");
+            } else {
+                useCustomStatusColors = false;
+                passedColor = PASSED_STATUS_COLOR;
+                failedColor = FAILED_STATUS_COLOR;
+                skippedColor = SKIP_STATUS_COLOR;
+                naColor = NA_STATUS_COLOR;
             }
             save();
             return true;

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension.java
@@ -57,6 +57,7 @@ public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
         private boolean showBarGraph = true;
         private boolean showPieGraph = true;
         private boolean hideConfigurationMethods = false;
+        private int hideNATestsThreshold = 0;
         private String runTimeLowThreshold = "0.5";
         private String runTimeHighThreshold = "1.0";
 
@@ -95,6 +96,7 @@ public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
                 showAllBuilds = formData.getBoolean("showAllBuilds");
                 showBuildTime = formData.getBoolean("showBuildTime");
                 hideConfigurationMethods = formData.getBoolean("hideConfigurationMethods");
+                hideNATestsThreshold = formData.getInt("hideNATestsThreshold");
                 showLineGraph = formData.getBoolean("showLineGraph");
                 showBarGraph = formData.getBoolean("showBarGraph");
                 showPieGraph = formData.getBoolean("showPieGraph");
@@ -162,6 +164,10 @@ public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
 
         public boolean getHideConfigurationMethods() {
             return hideConfigurationMethods;
+        }
+
+        public int getHideNATestsThreshold() {
+            return hideNATestsThreshold;
         }
 
         public boolean getShowBuildTime() {
@@ -234,6 +240,19 @@ public class TestResultsAnalyzerExtension extends TransientActionFactory<Job>
 
         public FormValidation doCheckNoOfBuilds(@QueryParameter String noOfBuilds) {
             return intValidation(noOfBuilds);
+        }
+
+        public FormValidation doCheckHideNATestsThreshold(@QueryParameter String hideNATestsThreshold) {
+            FormValidation result = intValidation(hideNATestsThreshold);
+            if (result.kind != FormValidation.Kind.OK) {
+                return result;
+            }
+
+            int value = Integer.parseInt(hideNATestsThreshold);
+            if (value < 0) {
+                return FormValidation.error("Entered value should be greater than or equal to 0");
+            }
+            return FormValidation.ok();
         }
 
         public FormValidation doCheckPassedRepresentation(@QueryParameter String passedRepresentation) {

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.testresultsanalyzer.config;
 
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Created by vmenon on 3/17/2016.
@@ -12,10 +13,9 @@ public class UserConfig {
     private String hideNATestsThreshold;
 
     @DataBoundConstructor
-    public UserConfig(String noOfBuildsNeeded, boolean hideConfigMethods, String hideNATestsThreshold) {
+    public UserConfig(String noOfBuildsNeeded, boolean hideConfigMethods) {
         this.noOfBuildsNeeded = noOfBuildsNeeded;
         this.hideConfigMethods = hideConfigMethods;
-        this.hideNATestsThreshold = hideNATestsThreshold;
     }
 
     public boolean isHideConfigMethods() {
@@ -38,6 +38,7 @@ public class UserConfig {
         return hideNATestsThreshold;
     }
 
+    @DataBoundSetter
     public void setHideNATestsThreshold(String hideNATestsThreshold) {
         this.hideNATestsThreshold = hideNATestsThreshold;
     }

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
@@ -9,11 +9,13 @@ public class UserConfig {
     private boolean hideConfigMethods = false;
 
     private String noOfBuildsNeeded;
+    private String hideNATestsThreshold;
 
     @DataBoundConstructor
-    public UserConfig(String noOfBuildsNeeded, boolean hideConfigMethods) {
+    public UserConfig(String noOfBuildsNeeded, boolean hideConfigMethods, String hideNATestsThreshold) {
         this.noOfBuildsNeeded = noOfBuildsNeeded;
         this.hideConfigMethods = hideConfigMethods;
+        this.hideNATestsThreshold = hideNATestsThreshold;
     }
 
     public boolean isHideConfigMethods() {
@@ -30,5 +32,13 @@ public class UserConfig {
 
     public void setNoOfBuildsNeeded(String noOfBuildsNeeded) {
         this.noOfBuildsNeeded = noOfBuildsNeeded;
+    }
+
+    public String getHideNATestsThreshold() {
+        return hideNATestsThreshold;
+    }
+
+    public void setHideNATestsThreshold(String hideNATestsThreshold) {
+        this.hideNATestsThreshold = hideNATestsThreshold;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
@@ -39,7 +39,6 @@ public class UserConfig {
     }
 
     @DataBoundSetter
-    @DataBoundSetter
     public void setHideNATestsThreshold(String hideNATestsThreshold) {
         this.hideNATestsThreshold = hideNATestsThreshold;
     }

--- a/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/testresultsanalyzer/config/UserConfig.java
@@ -39,6 +39,7 @@ public class UserConfig {
     }
 
     @DataBoundSetter
+    @DataBoundSetter
     public void setHideNATestsThreshold(String hideNATestsThreshold) {
         this.hideNATestsThreshold = hideNATestsThreshold;
     }

--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -59,6 +59,10 @@ var $j = jQuery.noConflict();
         	<td><input type="checkbox" id="hide-config-methods" name="hide-config-methods" checked="${it.hideConfigurationMethods}"/></td>
         </tr>
 		<tr>
+			<td>Hide tests with N/A in at least this many builds:</td>
+			<td><input id="hide-na-tests-threshold" type="number" value="${it.hideNATestsThreshold}" min="0" step="1"/></td>
+		</tr>
+		<tr>
 			<td>Chart type:</td>
 			<td>
 				<input id="linegraph" type="checkbox" checked="${it.showLineGraph}" /> Line

--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -166,6 +166,7 @@ Search: <input id="filter" class="table-filter" type="text" placeholder="Test/Cl
 		} else {
 			jQuery("#chartDataType").val("passfail");
 		}
+		restoreAnalyzerOptions();
 		setCustomStatuses();
 		populateTemplate();
 	});
@@ -200,6 +201,7 @@ Search: <input id="filter" class="table-filter" type="text" placeholder="Test/Cl
     });
 
 	jQuery("#getbuildreport").click(function () {
+		saveAnalyzerOptions();
 		populateTemplate();
 	});
 	

--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerAction/index.jelly
@@ -55,11 +55,11 @@ var $j = jQuery.noConflict();
 			<td><input type="checkbox" id="show-build-durations" name="show-build-durations" checked="${it.showBuildTime}"/></td>
 		</tr>
 		<tr>
-        	<td>Hide configuration methods (Only for TestNG results}</td>
+	        	<td>Hide configuration methods (Only for TestNG results)</td>
         	<td><input type="checkbox" id="hide-config-methods" name="hide-config-methods" checked="${it.hideConfigurationMethods}"/></td>
         </tr>
 		<tr>
-			<td>Hide tests with N/A in at least this many builds:</td>
+			<td>Hide tests with N/A for at least this many consecutive builds:</td>
 			<td><input id="hide-na-tests-threshold" type="number" value="${it.hideNATestsThreshold}" min="0" step="1"/></td>
 		</tr>
 		<tr>

--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension/global.jelly
@@ -16,6 +16,9 @@
 		<f:entry title="${%Hide configuration methods - Only for TestNG results}">
         	<f:checkbox name="hideConfigurationMethods" checked="${descriptor.getHideConfigurationMethods()}" />
         </f:entry>
+		<f:entry title="${%Hide tests with N/A in at least this many builds}" field="hideNATestsThreshold">
+			<f:number name="hideNATestsThreshold" value="${descriptor.getHideNATestsThreshold()}" min="0" step="1"/>
+		</f:entry>
 		<f:entry title="${%Show Line Graph}">
 			<f:checkbox name="showLineGraph" checked="${descriptor.getShowLineGraph()}" />
 		</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/testresultsanalyzer/TestResultsAnalyzerExtension/global.jelly
@@ -16,8 +16,8 @@
 		<f:entry title="${%Hide configuration methods - Only for TestNG results}">
         	<f:checkbox name="hideConfigurationMethods" checked="${descriptor.getHideConfigurationMethods()}" />
         </f:entry>
-		<f:entry title="${%Hide tests with N/A in at least this many builds}" field="hideNATestsThreshold">
-			<f:number name="hideNATestsThreshold" value="${descriptor.getHideNATestsThreshold()}" min="0" step="1"/>
+		<f:entry title="${%Hide tests with N/A for at least this many consecutive builds}" field="hideNATestsThreshold">
+			<f:number name="hideNATestsThreshold" value="${descriptor.getHideNATestsThreshold()}" min="0" step="1" checkMethod="post"/>
 		</f:entry>
 		<f:entry title="${%Show Line Graph}">
 			<f:checkbox name="showLineGraph" checked="${descriptor.getShowLineGraph()}" />

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -1,6 +1,84 @@
 var colTemplate = "{'cellClass':'col1','value':'build20','header':'20','title':'20'}";
 var reevaluateChartData = true;
 var displayValues = false;
+var analyzerOptionsStorageKey = "test-results-analyzer-options";
+
+function saveAnalyzerOptions() {
+    if (typeof(Storage) === "undefined") {
+        return;
+    }
+
+    var options = {
+        noOfBuilds: $j("#noofbuilds").val(),
+        allNoOfBuilds: $j("#allnoofbuilds").is(":checked"),
+        showBuildDurations: $j("#show-build-durations").is(":checked"),
+        hideConfigMethods: $j("#hide-config-methods").is(":checked"),
+        hideNATestsThreshold: $j("#hide-na-tests-threshold").val(),
+        lineGraph: $j("#linegraph").is(":checked"),
+        barGraph: $j("#bargraph").is(":checked"),
+        pieGraph: $j("#piegraph").is(":checked"),
+        chartDataType: $j("#chartDataType").val()
+    };
+
+    try {
+        localStorage.setItem(analyzerOptionsStorageKey, JSON.stringify(options));
+    } catch (e) {
+        // ignore storage issues
+    }
+}
+
+function restoreAnalyzerOptions() {
+    if (typeof(Storage) === "undefined") {
+        return;
+    }
+
+    var stored;
+    try {
+        stored = localStorage.getItem(analyzerOptionsStorageKey);
+    } catch (e) {
+        return;
+    }
+
+    if (!stored) {
+        return;
+    }
+
+    try {
+        var options = JSON.parse(stored);
+        if (options.noOfBuilds !== undefined) {
+            $j("#noofbuilds").val(options.noOfBuilds);
+        }
+        if (options.allNoOfBuilds !== undefined) {
+            $j("#allnoofbuilds").prop("checked", !!options.allNoOfBuilds);
+        }
+        if (options.showBuildDurations !== undefined) {
+            $j("#show-build-durations").prop("checked", !!options.showBuildDurations);
+        }
+        if (options.hideConfigMethods !== undefined) {
+            $j("#hide-config-methods").prop("checked", !!options.hideConfigMethods);
+        }
+        if (options.hideNATestsThreshold !== undefined) {
+            $j("#hide-na-tests-threshold").val(options.hideNATestsThreshold);
+        }
+        if (options.lineGraph !== undefined) {
+            $j("#linegraph").prop("checked", !!options.lineGraph);
+        }
+        if (options.barGraph !== undefined) {
+            $j("#bargraph").prop("checked", !!options.barGraph);
+        }
+        if (options.pieGraph !== undefined) {
+            $j("#piegraph").prop("checked", !!options.pieGraph);
+        }
+        if (options.chartDataType !== undefined) {
+            $j("#chartDataType").val(options.chartDataType);
+        }
+    } catch (e) {
+        return;
+    }
+
+    $j("#noofbuilds").attr("disabled", $j("#allnoofbuilds").is(":checked"));
+    $j("#bargraph").attr("disabled", $j("#chartDataType").val() == "runtime");
+}
 
 function clearedFilter(rows) {
     var levelsToShow = [0]; // stack to keep track of hierarchy

--- a/src/main/webapp/js/testresult.js
+++ b/src/main/webapp/js/testresult.js
@@ -88,6 +88,9 @@ function getUserConfig(){
 
     var hideConfig = $j("#hide-config-methods").is(":checked");
     userConfig["hideConfigMethods"] = hideConfig;
+
+    var hideNATestsThreshold = $j("#hide-na-tests-threshold").val();
+    userConfig["hideNATestsThreshold"] = hideNATestsThreshold;
     return userConfig;
 }
 

--- a/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
@@ -137,9 +137,9 @@ class JsTreeUtilTest {
         JSONObject method1Node =
                 buildNode("method1", jsonArray(buildNA(4), buildNA(3), method1Build2, method1Build1), jsonArray());
         JSONObject class1Node = buildNode(
-            "Class1", jsonArray(buildNA(4), buildNA(3), class1Build2, class1Build1), jsonArray(method1Node));
+                "Class1", jsonArray(buildNA(4), buildNA(3), class1Build2, class1Build1), jsonArray(method1Node));
         JSONObject pnNode =
-            buildNode("pn", jsonArray(buildNA(4), buildNA(3), pnBuild2, pnBuild1), jsonArray(class1Node));
+                buildNode("pn", jsonArray(buildNA(4), buildNA(3), pnBuild2, pnBuild1), jsonArray(class1Node));
 
         JSONObject expected = buildRoot(jsonArray("4", "3", "2", "1"), jsonArray(pnNode));
 

--- a/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
@@ -148,30 +148,32 @@ class JsTreeUtilTest {
 
     @Test
     void doesNotHideWhenNAValuesAreNotConsecutive() {
-    List<Integer> builds = Arrays.asList(5, 4, 3, 2, 1);
-    ResultInfo results = new ResultInfo();
+        List<Integer> builds = Arrays.asList(5, 4, 3, 2, 1);
+        ResultInfo results = new ResultInfo();
 
-    FakePackageResult packageFoo = new FakePackageResult("pn").addTest("Class1", "method1", TestStatus.Pass);
-    results.addPackage(4, packageFoo, "someUrl/");
-    results.addPackage(2, packageFoo, "someUrl/");
+        FakePackageResult packageFoo = new FakePackageResult("pn").addTest("Class1", "method1", TestStatus.Pass);
+        results.addPackage(4, packageFoo, "someUrl/");
+        results.addPackage(2, packageFoo, "someUrl/");
 
-    JSONObject method1Build4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 4);
-    JSONObject method1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 2);
-    JSONObject class1Build4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 4);
-    JSONObject class1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 2);
-    JSONObject pnBuild4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 4);
-    JSONObject pnBuild2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 2);
+        JSONObject method1Build4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 4);
+        JSONObject method1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 2);
+        JSONObject class1Build4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 4);
+        JSONObject class1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 2);
+        JSONObject pnBuild4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 4);
+        JSONObject pnBuild2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 2);
 
-    JSONObject method1Node = buildNode(
-        "method1", jsonArray(buildNA(5), method1Build4, buildNA(3), method1Build2, buildNA(1)), jsonArray());
-    JSONObject class1Node = buildNode(
-        "Class1", jsonArray(buildNA(5), class1Build4, buildNA(3), class1Build2, buildNA(1)), jsonArray(method1Node));
-    JSONObject pnNode =
-        buildNode("pn", jsonArray(buildNA(5), pnBuild4, buildNA(3), pnBuild2, buildNA(1)), jsonArray(class1Node));
+        JSONObject method1Node = buildNode(
+                "method1", jsonArray(buildNA(5), method1Build4, buildNA(3), method1Build2, buildNA(1)), jsonArray());
+        JSONObject class1Node = buildNode(
+                "Class1",
+                jsonArray(buildNA(5), class1Build4, buildNA(3), class1Build2, buildNA(1)),
+                jsonArray(method1Node));
+        JSONObject pnNode = buildNode(
+                "pn", jsonArray(buildNA(5), pnBuild4, buildNA(3), pnBuild2, buildNA(1)), jsonArray(class1Node));
 
-    JSONObject expected = buildRoot(jsonArray("5", "4", "3", "2", "1"), jsonArray(pnNode));
+        JSONObject expected = buildRoot(jsonArray("5", "4", "3", "2", "1"), jsonArray(pnNode));
 
-    assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 3));
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 3));
     }
 
     private static JSONObject buildRoot(JSONArray builds, JSONArray results) {

--- a/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
@@ -22,7 +22,7 @@ class JsTreeUtilTest {
         ResultInfo results = new ResultInfo();
 
         JSONObject expected = buildRoot(jsonArray(), jsonArray());
-        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false));
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 0));
     }
 
     @Test
@@ -31,7 +31,7 @@ class JsTreeUtilTest {
         ResultInfo results = new ResultInfo();
 
         JSONObject expected = buildRoot(jsonArray("9", "7", "6"), jsonArray());
-        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false));
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 0));
     }
 
     @Test
@@ -52,7 +52,7 @@ class JsTreeUtilTest {
 
         JSONObject expected = buildRoot(jsonArray("9", "7"), jsonArray(pnNode));
 
-        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false));
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 0));
     }
 
     @Test
@@ -77,7 +77,7 @@ class JsTreeUtilTest {
 
         JSONObject expected = buildRoot(jsonArray("1"), jsonArray(pnNode));
 
-        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false));
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 0));
     }
 
     @Test
@@ -102,7 +102,47 @@ class JsTreeUtilTest {
 
         JSONObject expected = buildRoot(jsonArray("1"), jsonArray(pnNode));
 
-        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false));
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 0));
+    }
+
+    @Test
+    void hideTestsWithThreeNAValues() {
+        List<Integer> builds = Arrays.asList(4, 3, 2, 1);
+        ResultInfo results = new ResultInfo();
+
+        FakePackageResult packageFoo = new FakePackageResult("pn").addTest("Class1", "method1", TestStatus.Pass);
+        results.addPackage(1, packageFoo, "someUrl/");
+
+        JSONObject expected = buildRoot(jsonArray("4", "3", "2", "1"), jsonArray());
+
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 3));
+    }
+
+    @Test
+    void doesNotHideWhenNAValuesBelowThreshold() {
+        List<Integer> builds = Arrays.asList(4, 3, 2, 1);
+        ResultInfo results = new ResultInfo();
+
+        FakePackageResult packageFoo = new FakePackageResult("pn").addTest("Class1", "method1", TestStatus.Pass);
+        results.addPackage(2, packageFoo, "someUrl/");
+        results.addPackage(1, packageFoo, "someUrl/");
+
+        JSONObject method1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 2);
+        JSONObject method1Build1 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 1);
+        JSONObject class1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 2);
+        JSONObject class1Build1 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 1);
+        JSONObject pnBuild2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 2);
+        JSONObject pnBuild1 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 1);
+
+        JSONObject method1Node =
+                buildNode("method1", jsonArray(buildNA(4), buildNA(3), method1Build2, method1Build1), jsonArray());
+        JSONObject class1Node =
+                buildNode("Class1", jsonArray(buildNA(4), buildNA(3), class1Build2, class1Build1), jsonArray(method1Node));
+        JSONObject pnNode = buildNode("pn", jsonArray(buildNA(4), buildNA(3), pnBuild2, pnBuild1), jsonArray(class1Node));
+
+        JSONObject expected = buildRoot(jsonArray("4", "3", "2", "1"), jsonArray(pnNode));
+
+        assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 3));
     }
 
     private static JSONObject buildRoot(JSONArray builds, JSONArray results) {

--- a/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
@@ -146,6 +146,34 @@ class JsTreeUtilTest {
         assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 3));
     }
 
+    @Test
+    void doesNotHideWhenNAValuesAreNotConsecutive() {
+    List<Integer> builds = Arrays.asList(5, 4, 3, 2, 1);
+    ResultInfo results = new ResultInfo();
+
+    FakePackageResult packageFoo = new FakePackageResult("pn").addTest("Class1", "method1", TestStatus.Pass);
+    results.addPackage(4, packageFoo, "someUrl/");
+    results.addPackage(2, packageFoo, "someUrl/");
+
+    JSONObject method1Build4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 4);
+    JSONObject method1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1/method1", 2);
+    JSONObject class1Build4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 4);
+    JSONObject class1Build2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn/Class1", 2);
+    JSONObject pnBuild4 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 4);
+    JSONObject pnBuild2 = buildLeaf(1, 0, 0, "PASSED", "someUrl/testReport/pn", 2);
+
+    JSONObject method1Node = buildNode(
+        "method1", jsonArray(buildNA(5), method1Build4, buildNA(3), method1Build2, buildNA(1)), jsonArray());
+    JSONObject class1Node = buildNode(
+        "Class1", jsonArray(buildNA(5), class1Build4, buildNA(3), class1Build2, buildNA(1)), jsonArray(method1Node));
+    JSONObject pnNode =
+        buildNode("pn", jsonArray(buildNA(5), pnBuild4, buildNA(3), pnBuild2, buildNA(1)), jsonArray(class1Node));
+
+    JSONObject expected = buildRoot(jsonArray("5", "4", "3", "2", "1"), jsonArray(pnNode));
+
+    assertEquals(expected, new JsTreeUtil().getJsTree(builds, results, false, 3));
+    }
+
     private static JSONObject buildRoot(JSONArray builds, JSONArray results) {
         JSONObject result = new JSONObject();
 

--- a/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
+++ b/src/test/java/org/jenkinsci/plugins/testresultsanalyzer/JsTreeUtilTest.java
@@ -136,9 +136,10 @@ class JsTreeUtilTest {
 
         JSONObject method1Node =
                 buildNode("method1", jsonArray(buildNA(4), buildNA(3), method1Build2, method1Build1), jsonArray());
-        JSONObject class1Node =
-                buildNode("Class1", jsonArray(buildNA(4), buildNA(3), class1Build2, class1Build1), jsonArray(method1Node));
-        JSONObject pnNode = buildNode("pn", jsonArray(buildNA(4), buildNA(3), pnBuild2, pnBuild1), jsonArray(class1Node));
+        JSONObject class1Node = buildNode(
+            "Class1", jsonArray(buildNA(4), buildNA(3), class1Build2, class1Build1), jsonArray(method1Node));
+        JSONObject pnNode =
+            buildNode("pn", jsonArray(buildNA(4), buildNA(3), pnBuild2, pnBuild1), jsonArray(class1Node));
 
         JSONObject expected = buildRoot(jsonArray("4", "3", "2", "1"), jsonArray(pnNode));
 


### PR DESCRIPTION
<!-- Comment:
Add configurable hiding of tests with consecutive N/A results
-->

<!-- in case you work on a Jira issue, replace [JENKINS-75315](https://issues.jenkins.io/browse/JENKINS-75315) with the numeric part of the issue ID you created in Jira -->

https://issues.jenkins.io/browse/JENKINS-75315?jql=resolution%20is%20EMPTY%20and%20component%3D19327

<!-- in case you work on github issue -->
See #XXXXX
<!-- in case this PR solves Github issue use close #### or closes, closed, fix, fixes, fixed, resolve, resolves, resolved -->

<!-- Comment:
If the issue is not fully described in Jira / Github, add more information here (justification, pull request links, etc.).

 * We do not require Jira / Github issues for minor improvements.
 * Bug fixes should have a Jira / Github issue to facilitate the backporting process.
 * Major new features should have a Jira / Github issue.
-->

### Testing done

<!-- Comment:
This change adds a configurable option to hide tests 2 that have been N/A for a configurable number of 3 consecutive builds. 4 5 Motivation: 6 The Test Results Analyzer can accumulate obsolete tests 7 over time, making the report harder to read. 8 This feature allows users to automatically hide inactive 9 tests while preserving useful history.
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira / Github issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood).
  - The changelog generator for plugins uses the **pull request title as the changelog entry**.
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during the upgrade.
- [x] There is automated testing or an explanation that explains why this change has no tests.
- [x] New public functions for internal use only are annotated with `@NoExternalUse`. In case it is used by non java code the `Used by {@code <panel>.jelly}` Javadocs are annotated.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease the future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Changes in the interface are documented.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the **pull request title** and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically. See also [release-drafter-labels](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50).
